### PR TITLE
Recursive Snapshot Enhancement

### DIFF
--- a/ec2_snapshot.py
+++ b/ec2_snapshot.py
@@ -266,18 +266,22 @@ def snapshot_retention(description_format, identifier, retention):
         elif snap1.start_time == snap2.start_time:
             return 0
         return 1
-    try:
-        snapshots = conn.get_all_snapshots()
-    except (boto.exception.AWSConnectionError, boto.exception.BotoServerError), e:
-        if MAX_RETRY > _retry_count:
-            logging.info("Can't connect to AWS, retrying..")
-        else:
-            logging.error("Unable to connect to AWS: %s", e)
-            sys.exit(1)
-        _retry_count += 1
-    except boto.exception, e:
-        logging.error("Unable to connect to AWS: %s", e)
-        sys.exit(1)
+    def get_all_snapshots(_retry_count):
+        """ Recursive snapshot query """
+        try:
+            snapshots = conn.get_all_snapshots()
+            return snapshots
+        except Exception, e:
+            if MAX_RETRY > _retry_count:
+                logging.info("Can't connect to AWS, retrying..")
+            else:
+                logging.error("Unable to connect to AWS after %s retries: %s", MAX_RETRY, e)
+                sys.exit(1)
+            _retry_count += 1
+            snapshots = get_all_snapshots(_retry_count)
+            return snapshots
+
+    snapshots = get_all_snapshots(_retry_count)
     del_snapshots = []
     for snapshot in snapshots:
         if snapshot.description.startswith("aws-tools"):

--- a/ec2_snapshot.py
+++ b/ec2_snapshot.py
@@ -207,10 +207,10 @@ def create_snapshot(conn, instance_id=None, volume_id=None, instance_name=None,
 
 def list_instance_details(verbose=False, instance_name=None):
     """
-    Returns a tag or dict containing instance details
-    Name - Tag: Name
-    ID - Instance ID
-    Volumes - List of volume IDs
+        Returns a tag or dict containing instance details
+        Name - Tag: Name
+        ID - Instance ID
+        Volumes - List of volume IDs
     """
     _retry_count = 0
     if instance_name:
@@ -253,9 +253,9 @@ def list_instance_details(verbose=False, instance_name=None):
 
 
 def snapshot_retention(description_format, identifier, retention):
-    """````
-    identifier = instance name, volume id, instance id
-    retention = dict of period and time delta
+    """
+        identifier = instance name, volume id, instance id
+        retention = dict of period and time delta
     """
     _retry_count = 0
 
@@ -266,6 +266,7 @@ def snapshot_retention(description_format, identifier, retention):
         elif snap1.start_time == snap2.start_time:
             return 0
         return 1
+
     def get_all_snapshots(_retry_count):
         """ Recursive snapshot query """
         try:


### PR DESCRIPTION
### Issue: 

When listing all snapshots, amazon can take longer than 60 seconds to respond. This causes the socket to close and results in an Error which is not currently not caught. Further Reading: https://github.com/boto/boto3/issues/185#issuecomment-125658863

### Example error where the socket timed out:

```
INFO:Creating snapshot: Snapshot:snap-00b38a7cc43bccd81
Traceback (most recent call last):
  File "ec2_snapshot.py", line 468, in <module>
    retention=retention
  File "ec2_snapshot.py", line 206, in create_snapshot
    snapshot_retention(description_format, identifier, retention)
  File "ec2_snapshot.py", line 271, in snapshot_retention
    snapshots = conn.get_all_snapshots()
  File "/usr/lib/python2.7/dist-packages/boto/ec2/connection.py", line 2303, in get_all_snapshots
    [('item', Snapshot)], verb='POST')
  File "/usr/lib/python2.7/dist-packages/boto/connection.py", line 1114, in get_list
    body = response.read()
  File "/usr/lib/python2.7/dist-packages/boto/connection.py", line 412, in read
    self._cached_response = httplib.HTTPResponse.read(self)
  File "/usr/lib/python2.7/httplib.py", line 578, in read
    return self._read_chunked(amt)
  File "/usr/lib/python2.7/httplib.py", line 636, in _read_chunked
    value.append(self._safe_read(chunk_left))
  File "/usr/lib/python2.7/httplib.py", line 693, in _safe_read
    chunk = self.fp.read(min(amt, MAXAMOUNT))
  File "/usr/lib/python2.7/socket.py", line 380, in read
    data = self._sock.recv(left)
  File "/usr/lib/python2.7/ssl.py", line 341, in recv
    return self.read(buflen)
  File "/usr/lib/python2.7/ssl.py", line 260, in read
    return self._sslobj.read(len)
socket.error: [Errno 104] Connection reset by peer
```

### Solution:
Implement a retry scenario and instead of catching specific errors and only trying on ones we know about, we need to retry on any exception, as any failure regardless should be retried. 